### PR TITLE
Remove gson and guava from staging jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,9 +173,6 @@ dependencies {
     def guava = 'com.google.guava:guava:21.0' // from mc1.12 onwards
     def gson = 'com.google.code.gson:gson:2.2.4'
 
-    stagingJar guava
-    stagingJar gson
-
     implementation guava
     implementation 'com.google.code.gson:gson:2.2.4'
     if (Float.parseFloat(asmVersion) < 6) {
@@ -384,7 +381,6 @@ task stagingJar(type: ShadowJar) {
     )
     
     mergeServiceFiles()
-    relocate 'com.google', 'org.spongepowered.include.com.google'
     archiveClassifier = "staging"
 }
 


### PR DESCRIPTION
In newer versions of minecraft you don't need to do this (it just adds unnecessary weight and java 9+ module conflict), in older versions it can be moved to the mixin loader mod (If necessary)

In fabric this was done because the loader itself does not contain guava or gson