### PR TITLE
Fix wrong call when interface don't exist on runtime

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/ClassInfo.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/ClassInfo.java
@@ -1248,7 +1248,12 @@ public final class ClassInfo {
         }
 
         for (String iface : this.interfaces) {
-            ClassInfo.forName(iface).addMethodsRecursive(methods, includeMixins);
+            ClassInfo classInfo = ClassInfo.forName(iface);
+            if (classInfo == null) {
+                ClassInfo.logger.debug("Failed to resolve implementing interface {} on {}", iface, this.name);
+                continue;
+            }
+            classInfo.addMethodsRecursive(methods, includeMixins);
         }
 
         return this.getSuperClass();


### PR DESCRIPTION
As the title indicated, some classes implemented interface that don't exist on runtime
(Forge have annotation [`@Interface`](https://nekoyue.github.io/ForgeJavaDocs-NG/javadoc/1.12.2/net/minecraftforge/fml/common/Optional.Interface.html) allow removal of interfaces if certain mods isn't available)
This should resolve issue by skipping interface(s) that not available during runtime

Info:
- [Latest log](https://github.com/LegacyModdingMC/UniMix/files/12293125/latest.log)
- [Debug log](https://github.com/LegacyModdingMC/UniMix/files/12293123/debug.log)