### PR TITLE
Remove version check for publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -587,4 +587,4 @@ task checkVersion {
     }
 }
 
-publish.mustRunAfter checkVersion
+//publish.mustRunAfter checkVersion


### PR DESCRIPTION
We don't use Fabric maven, so don't check it for already-published versions.