### PR TITLE
optimize Bytecode.getOpcodeName

### DIFF
--- a/src/main/java/org/spongepowered/asm/util/Bytecode.java
+++ b/src/main/java/org/spongepowered/asm/util/Bytecode.java
@@ -464,7 +464,7 @@ public final class Bytecode {
         } else if (node instanceof InvokeDynamicInsnNode) {
             InvokeDynamicInsnNode idc = (InvokeDynamicInsnNode)node;
             out += String.format("[%s] %s%s { %s %s::%s%s }", Bytecode.getOpcodeName(node), idc.name, idc.desc,
-                    Bytecode.getOpcodeName(idc.bsm.getTag(), "H_GETFIELD", 1), idc.bsm.getOwner(), idc.bsm.getName(), idc.bsm.getDesc());
+                    OpcodeNames.getOpcodeName(idc.bsm.getTag(), "H_GETFIELD", 1), idc.bsm.getOwner(), idc.bsm.getName(), idc.bsm.getDesc());
         } else if (node instanceof LineNumberNode) {
             LineNumberNode ln = (LineNumberNode)node;
             out += String.format("LINE=[%d] LABEL=[%s]", ln.line, ln.start.getLabel());
@@ -473,7 +473,7 @@ public final class Bytecode {
         } else if (node instanceof IntInsnNode) {
             out += (((IntInsnNode)node).operand);
         } else if (node instanceof FrameNode) {
-            out += String.format("[%s] ", Bytecode.getOpcodeName(((FrameNode)node).type, "H_INVOKEINTERFACE", -1));
+            out += String.format("[%s] ", OpcodeNames.getOpcodeName(((FrameNode)node).type, "H_INVOKEINTERFACE", -1));
         } else if (node instanceof TypeInsnNode) {
             out += String.format("[%s] %s", Bytecode.getOpcodeName(node), ((TypeInsnNode)node).desc);
         } else {
@@ -503,31 +503,9 @@ public final class Bytecode {
      *      the {@link Opcodes} class have the same value as opcodes
      */
     public static String getOpcodeName(int opcode) {
-        return Bytecode.getOpcodeName(opcode, "UNINITIALIZED_THIS", 1);
+        return OpcodeNames.getOpcodeName(opcode, "UNINITIALIZED_THIS", 1);
     }
 
-    private static String getOpcodeName(int opcode, String start, int min) {
-        if (opcode >= min) {
-            boolean found = false;
-            
-            try {
-                for (java.lang.reflect.Field f : Opcodes.class.getDeclaredFields()) {
-                    if (!found && !f.getName().equals(start)) {
-                        continue;
-                    }
-                    found = true;
-                    if (f.getType() == Integer.TYPE && f.getInt(null) == opcode) {
-                        return f.getName();
-                    }
-                }
-            } catch (Exception ex) {
-                // derp
-            }
-        }        
-        
-        return opcode >= 0 ? String.valueOf(opcode) : "UNKNOWN";
-    }
-    
     /**
      * Uses reflection to find a matching constant in the {@link Opcodes}
      * interface for the specified opcode name. Supported formats are raw
@@ -555,28 +533,8 @@ public final class Bytecode {
         if (!opcodeName.matches("^[A-Z][A-Z0-9_]+$")) {
             return -1;
         }
-        
-        return Bytecode.parseOpcodeName(opcodeName, "UNINITIALIZED_THIS", 1);
-    }
 
-    private static int parseOpcodeName(String opcodeName, String start, int min) {
-        boolean found = false;
-        
-        try {
-            for (java.lang.reflect.Field f : Opcodes.class.getDeclaredFields()) {
-                if (!found && !f.getName().equals(start)) {
-                    continue;
-                }
-                found = true;
-                if (f.getType() == Integer.TYPE && f.getName().equalsIgnoreCase(opcodeName)) {
-                    return f.getInt(null);
-                }
-            }
-        } catch (Exception ex) {
-            // well this is embarrassing
-        }
-        
-        return -1;
+        return OpcodeNames.parseOpcodeName(opcodeName, "UNINITIALIZED_THIS");
     }
 
     /**

--- a/src/main/java/org/spongepowered/asm/util/OpcodeNames.java
+++ b/src/main/java/org/spongepowered/asm/util/OpcodeNames.java
@@ -1,0 +1,108 @@
+package org.spongepowered.asm.util;
+
+import org.objectweb.asm.Opcodes;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public final class OpcodeNames {
+
+    private static final IntConstant[] ALL_INT_CONSTANTS = loadIntConstants();
+    private static final Map<String, FieldMappings> MAPPINGS_BY_START = new HashMap<>();
+
+    private OpcodeNames() {}
+
+    public static String getOpcodeName(int opcode, String startFrom, int min) {
+        if (opcode >= min) {
+            String name = getLookup(startFrom).valueToName.get(opcode);
+            if (name != null) {
+                return name;
+            }
+        }
+
+        return opcode >= 0 ? Integer.toString(opcode) : "UNKNOWN";
+    }
+
+    public static int parseOpcodeName(String opcodeName, String startFrom) {
+        if (opcodeName == null) {
+            return -1;
+        }
+
+        Integer opcode = getLookup(startFrom).nameToValue.get(opcodeName.toUpperCase(Locale.ROOT));
+        return opcode != null ? opcode : -1;
+    }
+
+    private static IntConstant[] loadIntConstants() {
+        Field[] fields = Opcodes.class.getDeclaredFields();
+        List<IntConstant> result = new ArrayList<>(fields.length);
+
+        for (Field field : fields) {
+            if (field.getType() != Integer.TYPE) {
+                continue;
+            }
+
+            try {
+                result.add(new IntConstant(field.getName(), field.getInt(null)));
+            } catch (Exception ignored) {
+                // public interface constants, so this should not happen
+            }
+        }
+
+        return result.toArray(new IntConstant[0]);
+    }
+
+    /**
+     * @param startFrom The name of the field in {@code Opcodes} from which name/value collection should begin
+     * @return {@link FieldMappings} which contains nameToValue and valueToName maps for given {@code startFrom}
+     */
+    private static FieldMappings getLookup(String startFrom) {
+        FieldMappings cached = MAPPINGS_BY_START.get(startFrom);
+        if (cached != null) {
+            return cached;
+        }
+
+        boolean reachedStartField = false;
+        Map<String, Integer> nameToValue = new HashMap<>();
+        Map<Integer, String> valueToName = new HashMap<>();
+
+        for (IntConstant constant : ALL_INT_CONSTANTS) {
+            if (!reachedStartField) {
+                if (!constant.name.equals(startFrom)) {
+                    continue;
+                }
+                reachedStartField = true;
+            }
+
+            nameToValue.putIfAbsent(constant.name.toUpperCase(Locale.ROOT), constant.value);
+            valueToName.putIfAbsent(constant.value, constant.name);
+        }
+
+        FieldMappings mappings = new FieldMappings(nameToValue, valueToName);
+        MAPPINGS_BY_START.put(startFrom, mappings);
+        return mappings;
+    }
+
+    private static final class IntConstant {
+        final String name;
+        final int value;
+
+        IntConstant(String name, int value) {
+            this.name = name;
+            this.value = value;
+        }
+    }
+
+    private static final class FieldMappings {
+        final Map<String, Integer> nameToValue;
+        final Map<Integer, String> valueToName;
+
+        FieldMappings(Map<String, Integer> nameToValue, Map<Integer, String> valueToName) {
+            this.nameToValue = nameToValue;
+            this.valueToName = valueToName;
+        }
+    }
+}


### PR DESCRIPTION
In my "before" profilt Bytecode.getOpcodeName takes ~1000ms of mc loading time, in my "after" profile only ~10ms

Before: (1026ms for shown ClassLoader.loadClass)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/576a7e67-3251-45aa-8a48-48aa585622b4" />

After: (606ms for shown ClassLoader.loadClass)
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f24b0b3b-b5a2-43a0-9e77-b7d5031d6ae4" />
